### PR TITLE
Add registration_numbers field to address types

### DIFF
--- a/api.gen.go
+++ b/api.gen.go
@@ -166,6 +166,27 @@ const (
 	PaymentRequestPaymentModePREPAID        PaymentRequestPaymentMode = "PRE_PAID"
 )
 
+// Defines values for RegistrationNumberTypeCode.
+const (
+	CNP  RegistrationNumberTypeCode = "CNP"
+	DUN  RegistrationNumberTypeCode = "DUN"
+	EIN  RegistrationNumberTypeCode = "EIN"
+	EOR  RegistrationNumberTypeCode = "EOR"
+	FED  RegistrationNumberTypeCode = "FED"
+	GST  RegistrationNumberTypeCode = "GST"
+	IE   RegistrationNumberTypeCode = "IE"
+	INN  RegistrationNumberTypeCode = "INN"
+	IOSS RegistrationNumberTypeCode = "IOSS"
+	KPP  RegistrationNumberTypeCode = "KPP"
+	OGR  RegistrationNumberTypeCode = "OGR"
+	OKP  RegistrationNumberTypeCode = "OKP"
+	PAN  RegistrationNumberTypeCode = "PAN"
+	SDT  RegistrationNumberTypeCode = "SDT"
+	SSN  RegistrationNumberTypeCode = "SSN"
+	STA  RegistrationNumberTypeCode = "STA"
+	VAT  RegistrationNumberTypeCode = "VAT"
+)
+
 // Defines values for RulesetRequestEntityType.
 const (
 	RulesetRequestEntityTypeFORWARD RulesetRequestEntityType = "FORWARD"
@@ -796,6 +817,9 @@ type FreeFormRequest struct {
 	// Postcode ZIP or postal code
 	Postcode *string `json:"postcode,omitempty"`
 
+	// RegistrationNumbers Array of registration numbers for customs/VAT purposes
+	RegistrationNumbers *[]RegistrationNumber `json:"registration_numbers,omitempty"`
+
 	// State State, county, province, or region, represented by the Carriyo State Code if known. If not, it's a free text.
 	//
 	// **Note: The state is automatically set if a standard Carriyo city is passed.**
@@ -1041,6 +1065,9 @@ type LocationObject struct {
 
 	// Postcode ZIP or postal code
 	Postcode *string `json:"postcode,omitempty"`
+
+	// RegistrationNumbers Array of registration numbers for customs/VAT purposes
+	RegistrationNumbers *[]RegistrationNumber `json:"registration_numbers,omitempty"`
 
 	// State State, county, province, or region, represented by the Carriyo State Code if known. If not, it's a free text.
 	//
@@ -1338,6 +1365,21 @@ type ReferencesRequest struct {
 	// PartnerShipmentReference Unique shipment reference provided by the merchant
 	PartnerShipmentReference string `json:"partner_shipment_reference"`
 }
+
+// RegistrationNumber Registration number for customs/VAT purposes
+type RegistrationNumber struct {
+	// IssuerCountryCode ISO 3166-1 alpha-2 country code of the issuer
+	IssuerCountryCode string `json:"issuer_country_code"`
+
+	// TypeCode Type of registration number
+	TypeCode RegistrationNumberTypeCode `json:"type_code"`
+
+	// Value The registration number value
+	Value string `json:"value"`
+}
+
+// RegistrationNumberTypeCode Type of registration number
+type RegistrationNumberTypeCode string
 
 // RulesetRequest defines model for ruleset-request.
 type RulesetRequest struct {

--- a/go.mod
+++ b/go.mod
@@ -8,27 +8,6 @@ require github.com/oapi-codegen/runtime v1.1.1
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
-	github.com/getkin/kin-openapi v0.127.0 // indirect
-	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.5.0 // indirect
-	github.com/gotesttools/gotestfmt/v2 v2.5.0 // indirect
-	github.com/invopop/yaml v0.3.1 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1 // indirect
-	github.com/perimeterx/marshmallow v1.1.5 // indirect
-	github.com/rogpeppe/go-internal v1.13.1 // indirect
-	github.com/speakeasy-api/openapi-overlay v0.9.0 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
-	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.13.0 // indirect
-	golang.org/x/text v0.24.0 // indirect
-	golang.org/x/tools v0.32.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -4247,6 +4247,45 @@ components:
           type: string
           description: 'ID type'
           example: Passport
+    registration-number:
+      title: Registration Number
+      type: object
+      description: Registration number for customs/VAT purposes
+      properties:
+        type_code:
+          type: string
+          description: Type of registration number
+          enum:
+            - VAT
+            - EIN
+            - GST
+            - SSN
+            - EOR
+            - DUN
+            - FED
+            - STA
+            - CNP
+            - IE
+            - INN
+            - KPP
+            - OGR
+            - OKP
+            - SDT
+            - IOSS
+            - PAN
+          example: VAT
+        value:
+          type: string
+          description: The registration number value
+          example: GB123456789
+        issuer_country_code:
+          type: string
+          description: ISO 3166-1 alpha-2 country code of the issuer
+          example: GB
+      required:
+        - type_code
+        - value
+        - issuer_country_code
     address-code:
       title: Address Code
       type: object
@@ -4365,6 +4404,11 @@ components:
             $ref: '#/components/schemas/address-code'
         personal_id:
           $ref: '#/components/schemas/personal_id'
+        registration_numbers:
+          type: array
+          description: Array of registration numbers for customs/VAT purposes
+          items:
+            $ref: '#/components/schemas/registration-number'
         street:
           type: string
           description: Street number or name
@@ -4579,6 +4623,11 @@ components:
             $ref: '#/components/schemas/address-code'
         personal_id:
           $ref: '#/components/schemas/personal_id'
+        registration_numbers:
+          type: array
+          description: Array of registration numbers for customs/VAT purposes
+          items:
+            $ref: '#/components/schemas/registration-number'
         street:
           type: string
           description: Street number or name


### PR DESCRIPTION
## Summary
- Add `RegistrationNumber` type with `type_code` enum, `value`, and `issuer_country_code` fields
- Add `registration_numbers` field to `FreeFormRequest` and `LocationObject` for pickup/dropoff addresses
- Support customs/VAT registration numbers with types: VAT, EIN, GST, SSN, EOR, DUN, FED, STA, CNP, IE, INN, KPP, OGR, OKP, SDT, IOSS, PAN

## Test plan
- [ ] Verify generated types compile correctly
- [ ] Test serialization/deserialization of registration numbers in API requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for customs/VAT registration numbers in address payloads.
> 
> - Introduces `RegistrationNumber` model (`type_code`, `value`, `issuer_country_code`) with `RegistrationNumberTypeCode` enum (VAT, EIN, GST, SSN, EOR, DUN, FED, STA, CNP, IE, INN, KPP, OGR, OKP, SDT, IOSS, PAN)
> - Adds `registration_numbers` array to `FreeFormRequest` and `LocationObject` address types in generated `api.gen.go`
> - Updates OpenAPI (`spec.yml`) with `registration-number` schema and integrates `registration_numbers` into pickup/dropoff address definitions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad65207c4866abfe19cc11b5d72f4fab60aa9251. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->